### PR TITLE
[html-alt-tech] Reference correct images

### DIFF
--- a/html-alt-techniques/index.html
+++ b/html-alt-techniques/index.html
@@ -385,7 +385,7 @@ padding:0 1em;
       <p><a href="http://www.w3.org/TR/html5/links.html#hyperlink">ハイパーリンク</a>、または<a href="http://www.w3.org/TR/html5/forms.html#the-button-element">button</a>要素をもつ<a href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a>要素が、テキストコンテンツがないが1つ以上の画像を含む場合、<code>alt</code>属性がリンクやボタンの目的を同時に伝えるテキストを含みます。</p>
       <div class="example">
        <p>この例において、エディターインターフェースの一部が表示されています。各ボタンは、ユーザーが編集しているコンテンツに対して実行できるアクションを表すアイコンを持ちます。画像を見ることができないユーザーのために、アクション名は画像の<code>alt</code>属性内に含まれます：</p>
-        <p><img alt="5つのボタン：太字、斜体、打ち消し線、箇条書きリストおよび番号付きリスト。" src="images/buttons1.png"></p>
+        <p><img alt="5つのボタン：太字、斜体、打ち消し線、箇条書きリストおよび番号付きリスト。" src="http://www.w3.org/TR/html-alt-techniques/images/buttons1.png"></p>
         <pre>  &lt;ul&gt;
   &lt;li&gt;&lt;button&gt;&lt;img src="b.png" <strong>alt="Bold"</strong>&gt;&lt;/button&gt;&lt;/li&gt;
   &lt;li&gt;&lt;button&gt;&lt;img src="i.png" <strong>alt="Italics"</strong>&gt;&lt;/button&gt;&lt;/li&gt;
@@ -419,7 +419,7 @@ padding:0 1em;
       </div>
       <div class="example">
         <p>この例で、ボタンは検索アイコンを含んでいます。ボタンは検索フォームを送信します。代替テキストはボタンが何をするかの簡単な説明です。</p>
-        <p><img width="74" height="29" alt="検索アイコンはボタンコンテンツとして使用されます。" src="images/search.png"></p>
+        <p><img width="74" height="29" alt="検索アイコンはボタンコンテンツとして使用されます。" src="http://www.w3.org/TR/html-alt-techniques/images/search.png"></p>
         <pre><code class="block">&lt;button&gt;
 &lt;img src="images/search.png" width="74" height="29" <mark>alt="Search"</mark>&gt;
 &lt;/button&gt;</code>    </pre>
@@ -436,7 +436,7 @@ padding:0 1em;
       <p>たとえばフローチャート、図表、グラフ、または方角を示す地図などとして、グラフ形式でコンテンツが表示される際にユーザーは恩恵を受けることができます。グラフ形式で提示されるコンテンツもテキスト形式で提供される場合、ユーザーもまた利益を得ます。このユーザーは、画像を表示できない人たちを含みます。（たとえば、非常に低速な接続である、またはテキストのみのブラウザを使用している、またはハンズフリー自動車音声ウェブブラウザによって読み出されるページを聞いている、あるいは、視覚障害を持ち、テキストを音声にレンダリングする支援技術使用しているため。）</p>
       <div class="example">
         <p>次の円グラフの画像例において、円グラフに表示されるデータを表す<code>alt</code>属性でテキストをもちます：</p>
-        <p><img width="380" height="299" alt="Browser Share: Internet Explorer 25%, Firefox 40%, Chrome 25%, Safari 6% and Opera 4%." src="images/browserShare.png"></p>
+        <p><img width="380" height="299" alt="Browser Share: Internet Explorer 25%, Firefox 40%, Chrome 25%, Safari 6% and Opera 4%." src="http://www.w3.org/TR/html-alt-techniques/images/browserShare.png"></p>
         <pre><code class="block">&lt;img src="piechart.gif" <mark>alt="Pie chart: Browser Share - Internet Explorer 25%,
 Firefox 40%, Chrome 25%, Safari 6% and Opera 4%."</mark>&gt;</code>    </pre>
       </div>
@@ -446,12 +446,12 @@ Firefox 40%, Chrome 25%, Safari 6% and Opera 4%."</mark>&gt;</code>    </pre>
 Chrome has 25%, Safari has 6% and Opera has 4%.&lt;/p&gt;
 &lt;p&gt;&lt;img src="piechart.gif" <mark>alt="Pie chart representing the data in the previous paragraph."</mark>&gt;&lt;/p&gt;</code></pre>
         <p>たとえばsrc属性値が間違っているため、画像が利用できない場合に、代替テキストが画像コンテンツの簡単な説明をユーザーに提供するのが見られます：</p>
-        <p><img alt="Representation of the code snippet above." src="images/brokenimg.png"></p>
+        <p><img alt="Representation of the code snippet above." src="http://www.w3.org/TR/html-alt-techniques/images/brokenimg.png"></p>
       </div>
       <p>代替テキストが長くなる場合において、1つ以上の文は、構造化マークアップを使用することの恩恵を受けるだろう、簡単な説明または<code>alt</code>属性を使用するラベル、および関連付けられた代替テキストを提供します。</p>
       <div class="example">
         <p>これは、<code>alt</code>属性に含まれる短い代替テキストをもフローチャート画像の例です。この場合、代替テキストは画像が唯一のリンク内容としてリンク先の説明となります。リンクは、フローチャートで表されるプロセスの、同じ文書内での説明を指します。</p>
-        <p><img width="221" height="320" alt="Flowchart: Dealing with a broken lamp." src="images/flowchart.png"></p>
+        <p><img width="221" height="320" alt="Flowchart: Dealing with a broken lamp." src="http://www.w3.org/TR/html-alt-techniques/images/flowchart.png"></p>
         <pre><code class="block"><mark>&lt;a href="#desc"&gt;</mark>&lt;img src="flowchart.gif" <mark>alt="Flowchart: Dealing with a broken lamp."</mark>&gt;<mark>&lt;/a&gt;</mark>
 ...
 ...
@@ -525,26 +525,26 @@ Chrome has 25%, Safari has 6% and Opera has 4%.&lt;/p&gt;
       <p>時には、画像はテキストのみを含み、そして画像の目的が、視覚効果とフォントの両方またはいずれか一方を用いるテキストを表示することにある。CSSを用いたスタイル付きテキストを使用することを<em>強く</em>推奨しますが、これが不可能な場合、画像であるがままに<a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-img-alt">alt</a>属性で同じテキストを提供します。</p>
       <div class="example">
         <p>この例は、テキストの画像を"Get Happy!"と表示する。派手な色とりどりのフリーハンドスタイルで書かれている。画像は見出しの内容を構成する。この例において、画像の代替テキストは"Get Happy!"とすべきです。</p>
-        <p><img width="275" height="77" alt="Get Happy!" src="images/text.png"></p>
+        <p><img width="275" height="77" alt="Get Happy!" src="http://www.w3.org/TR/html-alt-techniques/images/text.png"></p>
         <pre><code class="block">&lt;h1&gt;&lt;img src="gethappy.gif" <mark>alt="Get Happy!"</mark>&gt;&lt;/h1&gt;</code></pre>
       </div>
       <div class="example">
         <p>この例では、テキストからなる広告画像であり、フレーズ"The BIG sale"が3回繰り返され、回を重ねるごとにテキストはより小さくかつより暗くなり、最後の行は "...ends Friday"と読む。広告として、コンテキストにおける使用は、画像の代替テキストは一度だけテキスト"The BIG sale"を含むことが推奨されます。視覚効果とテキストの繰り返しは、画像が表示できないユーザーにとって不要であり、混乱を招くかもしれません。</p>
-        <p><img width="400" height="190" alt="The big sale ...ends Friday." src="images/sale.png"></p>
+        <p><img width="400" height="190" alt="The big sale ...ends Friday." src="http://www.w3.org/TR/html-alt-techniques/images/sale.png"></p>
         <pre>  <code class="block">&lt;p&gt;&lt;img src="sale.gif" <mark>alt="The BIG sale ...ends Friday."</mark>&gt;&lt;/p&gt;</code>    </pre>
         <p>テキストの画像と一緒に写真または他のグラフィックも存在する状況において、情報がまた画像を表示できないユーザーにも使用できるように、画像を表示できるユーザーに意味を伝える画像の他の説明とともに、代替テキストに含まれている画像テキスト内の単語を保証します。</p>
       </div>
       <p>画像がUnicodeで表現できない文字を表すために別の方法で使用される場合、たとえば外字、異体字、または新規の通貨記号のような新しい文字において、代替テキストは、たとえば、文字の発音を与えるために表音のひらがなやカタカナを使用するなど、同じものを記述するより伝統的な方法であるべきです。</p>
       <div class="example">
         <p>1997年からのこの例において、中央の2つのバーとともに渦巻き状のEのように見える最新式の通貨記号のかわりに、画像を使用して表現されます。代替テキストは、文字の発音を与えます。</p>
-        <p>Only <img width="21" height="18" alt="euro " src="images/euro.png">5.99!</p>
+        <p>Only <img width="21" height="18" alt="euro " src="http://www.w3.org/TR/html-alt-techniques/images/euro.png">5.99!</p>
         <pre><code class="block">&lt;p&gt;Only &lt;img src="euro.png" alt="euro "&gt;5.99!</code></pre>
       </div>
       <p>Unicode文字が同じ目的を果たす場合に画像を使用すべきではありません。たとえば装飾のためや、文字がUnicode文字集合にない（外字の場合のような）文字であるためなど、テキストが直接Unicodeを使用して表すことができない場合にのみ、画像が適切になります。</p>
       <p>デフォルトのシステムフォントが指定された文字をサポートしないため、著者が画像を使用するように誘惑される場合、ウェブフォントは画像よりも優れた解決策です。</p>
       <div class="example">
         <p>装飾写本は、その文字の一部のグラフィックスを使用するかもしれません。このような状況で代替テキストは、単に画像が表す文字です。</p>
-        <p><img width="24" height="32" alt="O" src="images/fancyO.png">nce upon a time and a long long time ago...</p>
+        <p><img width="24" height="32" alt="O" src="http://www.w3.org/TR/html-alt-techniques/images/fancyO.png">nce upon a time and a long long time ago...</p>
         <pre><code class="block">&lt;p&gt;&lt;img src="initials/fancyO.png" alt="O"&gt;nce upon a time and a long long time ago...</code></pre>
       </div>
       </section><section id="images-that-include-text-1" typeof="bibo:Chapter" rel="bibo:Chapter" resource="#images-that-include-text">
@@ -552,7 +552,7 @@ Chrome has 25%, Safari has 6% and Opera has 4%.&lt;/p&gt;
       <p>時には、画像はグラフおよび関連するテキストのようなグラフィックスを構成します。この場合、代替テキストに画像内のテキストを含めることを推奨します。</p>
       <div class="example">
         <p>円グラフと関連するテキストを含む画像を考えてみましょう。テキストの画像でなく、任意の関連するテキストを可能な限りテキストとして提供することを推奨します。これが不可能な場合、画像で伝えられる関連情報とともに代替テキスト内のテキストを含みます。</p>
-        <p><img width="351" height="279" id="piechart" alt="図1。Distribution of Articles by Journal     Category. 円グラフ：Language=68%, Education=14% and Science=18%." src="images/figure1.png"></p>
+        <p><img width="351" height="279" id="piechart" alt="図1。Distribution of Articles by Journal     Category. 円グラフ：Language=68%, Education=14% and Science=18%." src="http://www.w3.org/TR/html-alt-techniques/images/figure1.png"></p>
         <pre><code class="block">&lt;p&gt;&lt;img src="figure1.gif" <mark>alt="Figure 1. Distribution of Articles by Journal Category.
 Pie chart: Language=68%, Education=14% and Science=18%."</mark>&gt;&lt;/p&gt; </code>   </pre>
       </div>
@@ -588,7 +588,7 @@ Two have blown out.</mark> <mark>&lt;a href=" http://www.tate.org.uk/servlet/Vie
       </div>
       <div class="example">
         <p>この例は、ページの主題の写真として画像を識別する代替テキストの提供を説明します。</p>
-        <img width="354" height="138" alt="Portrait photo(black and white) of Robin, accompanied by a heading 'Robin Berjon' and a question    'what more needs to be said?'" src="images/robin.png">
+        <img width="354" height="138" alt="Portrait photo(black and white) of Robin, accompanied by a heading 'Robin Berjon' and a question    'what more needs to be said?'" src="http://www.w3.org/TR/html-alt-techniques/images/robin.png">
         <pre><code class="block">&lt;img src="orateur_robin_berjon.png" <mark>alt="Portrait photo(black and white) of Robin."</mark>&gt;
 &lt;h1&gt;Robin Berjon&lt;/h1&gt;
 &lt;p&gt;What more needs to be said?&lt;/p&gt;</code>    </pre>
@@ -623,7 +623,7 @@ Two have blown out.</mark> <mark>&lt;a href=" http://www.tate.org.uk/servlet/Vie
       <div class="example">
         <p>ある人のブログの装飾バナーとして使用される画像の例では、画像は何も情報を提供しないので、空の<code>alt</code>属性を持つべきです。</p>
         <div>
-          <p><img width="400" height="30" alt="" src="images/border.png"></p>
+          <p><img width="400" height="30" alt="" src="http://www.w3.org/TR/html-alt-techniques/images/border.png"></p>
           <p><strong>Clara's Blog</strong></p>
           <p>Welcome to my blog...</p>
         </div>
@@ -654,7 +654,7 @@ Two have blown out.</mark> <mark>&lt;a href=" http://www.tate.org.uk/servlet/Vie
       </div>
       <div class="example">
         <p>次の例において、評価は、3つの塗りつぶされた星と、2つの中抜きの星として示されます。代替テキストは"★★★☆☆"かもしれないが、代わりに著者は、より親切な形式"3 out of 5"の評価を与えるようにしています。これは最初の画像の代替テキストであり、残りは空の<code>alt</code>属性を持ちます。</p>
-        <p><img width="149" height="30" alt="3 out of 5." src="images/rating.png"></p>
+        <p><img width="149" height="30" alt="3 out of 5." src="http://www.w3.org/TR/html-alt-techniques/images/rating.png"></p>
         <pre><code class="block">&lt;p&gt;Rating: &lt;meter max=5 value=3&gt;
 &lt;img src="1" <mark>alt="3 out of 5"</mark>&gt;
 &lt;img src="1" <mark>alt=""</mark>&gt;
@@ -668,7 +668,7 @@ Two have blown out.</mark> <mark>&lt;a href=" http://www.tate.org.uk/servlet/Vie
 <a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-img-element">img</a>要素が、href属性を持つ<a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-area-element">area</a>要素を含む<a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-map-element">map</a>要素を参照する<a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-map-element">usemap</a>属性を持つ場合、<a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-img-element">img</a>はインタラクティブコンテンツであると見なされます。このような場合、<code>alt</code>属性を使用して画像の代替テキストを常に提供します。
 <div class="example">
   <p><a href="http://en.wikipedia.org/wiki/Katoomba,_New_South_Wales">カトゥーンバ</a>の地図である以下の画像を考えてみます。地図が南北カトゥーンバの領域に対応する2つのインタラクティブ領域を持ちます。</p>
-  <p><img width="209" height="249" alt="Map of Katoomba." src="images/imagemap.png" usemap="#Map"></p>
+  <p><img width="209" height="249" alt="Map of Katoomba." src="http://www.w3.org/TR/html-alt-techniques/images/imagemap.png" usemap="#Map"></p>
   <map name="Map">
     <area href="http://www.w3.org/TR/html5/embedded-content-0.html#" shape="poly" coords="78,124,124,10,189,29,173,93,168,132,136,151,110,130" alt="North Katoomba">
     <area href="http://www.w3.org/TR/html5/embedded-content-0.html#" shape="poly" coords="66,63,80,135,106,138,137,154,167,137,175,133,144,240,49,223,17,137,17,61" alt="South Katoomba">
@@ -691,7 +691,7 @@ alt="Houses in South Katoomba" href="south.html"&gt;
 <p>複数画像から合成写真を作成する場合、画像の1つ以上をリンクしたいと思うかもしれません。リンクの目的を説明するために、各リンクされた画像に対して<a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-img-alt">alt</a>属性を提供します。 </p>
 <div class="example">
   <p>次の例において、合成写真は"Crocoduck"を示すために使用されます。これは、ワニの一部とアヒルの一部によって進化の原則を無視する架空の生き物です。Crocoduckと交流するように求めていますが、用心する必要があります。</p>
-  <p><img alt="crocodile's angry, chomping head" src="images/crocoduck1.png"><img alt="duck's soft, feathery body" src="images/crocoduck2.png"></p>
+  <p><img alt="crocodile's angry, chomping head" src="http://www.w3.org/TR/html-alt-techniques/images/crocoduck1.png"><img alt="duck's soft, feathery body" src="http://www.w3.org/TR/html-alt-techniques/images/crocoduck2.png"></p>
   <pre> &lt;h1&gt;The crocoduck&lt;/h1&gt;
 &lt;p&gt;You encounter a strange creature called a "crocoduck". The creature seems angry!
 Perhaps some friendly stroking will help to calm it, but be careful not to stroke
@@ -705,7 +705,7 @@ any crocodile parts. This would just enrage the beast further.&lt;/p&gt;
 <p>画像に対する適切な​代替テキストは簡単な説明、または<a href="http://waic.jp/docs/WCAG20/Overview.html#namedef">識別名</a>です[<a href="#bib-WCAG20">WCAG</a>]。すべての代替テキストのオーサリングの決定のように、画像に対して適切な代替テキストを書くことは人間の判断を必要とします。テキスト値は、画像が使用されるコンテキストとページ作者の文体の主観的なものです。したがって、特定の画像に対するaltテキストの'正しい'ものはありません。非テキストコンテンツの簡単な説明を与える簡潔な代替テキストの提供に加えて、適切な有用である場合にも別のものを介して補足的コンテンツの提供を意味します。</p>
 <div class="example">
   <p>この例は、写真共有サイトにアップロードした画像を示します。写真は風呂に座っている猫です。画像は、<a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-img-element">img</a>要素の<code>alt</code>属性を用いて提供される代替テキストを持ちます。画像はまた、<a href="http://www.w3.org/TR/html5/grouping-content.html#the-figure-element">figure</a>要素において<a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-img-element">img</a>要素を含む、およびキャプションテキストを識別するために<a href="http://www.w3.org/TR/html5/grouping-content.html#the-figcaption-element">figcaption</a>要素を使用することによって、提供されるキャプションも持ちます。</p>
-  <p><img width="300" height="242" alt="ローラ猫は、お風呂の浴槽に傘の下で座っている。" src="images/lola.png"></p>
+  <p><img width="300" height="242" alt="ローラ猫は、お風呂の浴槽に傘の下で座っている。" src="http://www.w3.org/TR/html-alt-techniques/images/lola.png"></p>
   <p>Lola prefers a bath to a shower.</p>
   <pre><code class="block">&lt;figure&gt;
 &lt;img src="664aef.jpg" <mark>alt="Lola the cat sitting under an umbrella in the bath tub."</mark>&gt;
@@ -714,7 +714,7 @@ any crocodile parts. This would just enrage the beast further.&lt;/p&gt;
 </div>
 <div class="example">
   <p>画像の主題が解釈が自由であるため、この例は完全な記述を受け付けない画像です。画像を表示できないユーザーにどのような画像であるかを提供する<code>alt</code>属性で代替テキストを画像は持ちます。画像はまた、<a href="http://www.w3.org/TR/html5/grouping-content.html#the-figure-element">figure</a>要素において<a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-img-element">img</a>要素を含む、およびキャプションテキストを識別するために<a href="http://www.w3.org/TR/html5/grouping-content.html#the-figcaption-element">figcaption</a>要素を使用することによって、提供されるキャプションも持ちます。</p>
-  <p><img width="300" height="197" alt="An abstract, freeform, vertically symmetrical, black inkblot on a light background." src="images/inkblot1.png"></p>
+  <p><img width="300" height="197" alt="An abstract, freeform, vertically symmetrical, black inkblot on a light background." src="http://www.w3.org/TR/html-alt-techniques/images/inkblot1.png"></p>
   <p>The first of the ten cards in the Rorschach test.</p>
   <pre><code class="block">&lt;figure&gt;
 &lt;img src="Rorschach1.jpg"
@@ -728,7 +728,7 @@ any crocodile parts. This would just enrage the beast further.&lt;/p&gt;
 <div class="example">
   <p>この例はかなり典型的です。タイトルとタイムスタンプは画像に含まれ、自動的にウェブカメラのソフトウェアによって生成されます。テキスト情報が画像に含まれていなかった場合、より良かっただろうが、テキスト情報は画像の一部であるように、画像はテキスト情報の一部を含みます。キャプションはまた、<a href="http://www.w3.org/TR/html5/grouping-content.html#the-figure-element">figure</a>および<a href="http://www.w3.org/TR/html5/grouping-content.html#the-figcaption-element">figcaption</a>要素を使って提供されます。画像は建物近くの現在の天気について視覚情報を伝えるために提供されますが、ウェブカメラの画像が自動的に生成されてアップロードされるので、地元の天気予報が提供されるリンクが、代替テキストとしての情報を提供することは実用的でないでしょう。</p>
   <p><code>alt</code>属性のテキストは、音声ソフトウェアへのテキストによって知らせる場合にテキストをよりわかりやすくするために設計された、タイムスタンプの単調なバージョンを含みます。気象条件と日時が変化するにもかかわらず、代替テキストはまた、変化しない画像で見られることの一部の側面の記述を含みます。</p>
-  <p><img width="296" height="225" alt="Sopwith house weather cam. Taken on the 21/04/10 at 11:51 and 34 seconds. In the foreground are the safety    rails on the flat part of the roof. Nearby ther are low rise industrial buildings, beyond those are block of flats. In the distance there's a    church steeple." src="images/webcam1.png"></p>
+  <p><img width="296" height="225" alt="Sopwith house weather cam. Taken on the 21/04/10 at 11:51 and 34 seconds. In the foreground are the safety    rails on the flat part of the roof. Nearby ther are low rise industrial buildings, beyond those are block of flats. In the distance there's a    church steeple." src="http://www.w3.org/TR/html-alt-techniques/images/webcam1.png"></p>
   <p>View from the top of Sopwith house, looking towards North Kingston. This image is updated every hour.</p>
   <p>View the <a href="http://news.bbc.co.uk/weather/forecast/4296?area=Kingston">latest weather details</a> for Kingston upon Thames.</p>
   <pre><code class="block">&lt;figure&gt;
@@ -755,7 +755,7 @@ for Kingston upon Thames.&lt;/p&gt;    </code></pre>
 <div class="example">
   <p>この例において、写真共有サイトに多数の画像のようなバルクアップロードの一部として、ある人が写真をアップロードします。ユーザーは、代替テキストや画像のキャプションを提供していません。サイトのオーサリングツールは、画像に対して持っている有用な情報を使ってキャプションを自動的に挿入します。この場合において、それはファイル名および、写真が撮影された日付です。</p>
   <p class="warning">下記例のキャプションテキストは適切な代替テキストでなく、Webアクセシビリティガイドライン2.0に準拠していません。<span>[<cite><a class="bibref" href="#bib-WCAG20">WCAG20</a></cite>]</span></p>
-  <p><img width="300" height="258" alt="no text alternative provided" src="images/clara.png"></p>
+  <p><img width="300" height="258" alt="no text alternative provided" src="http://www.w3.org/TR/html-alt-techniques/images/clara.png"></p>
   <p>clara.jpg, taken on 12/11/2010.</p>
   <pre><code class="block">&lt;figure&gt;
 &lt;img src="clara.jpg"&gt;
@@ -765,7 +765,7 @@ for Kingston upon Thames.&lt;/p&gt;    </code></pre>
 </div>
 <div class="example">
   <p>次の2番目の例において、ある人が写真共有サイトに写真をアップロードします。彼女は、代替テキストでなく、画像のキャプションを提供しています。サイトは<code>alt</code>属性で代替テキストを追加する機能をユーザーに提供していないため、この可能性があります。</p>
-  <p><img width="205" height="250" alt="no text alternative provided" src="images/elo.png"></p>
+  <p><img width="205" height="250" alt="no text alternative provided" src="http://www.w3.org/TR/html-alt-techniques/images/elo.png"></p>
   <p><strong>Eloisa with Princess Belle</strong></p>
   <pre><code class="block">&lt;figure&gt;
 &lt;img src="elo.jpg"&gt;
@@ -815,7 +815,7 @@ for Kingston upon Thames.&lt;/p&gt;    </code></pre>
 <p>アイコンが同じ意味を伝えるテキストを補足する際に空の<code>alt</code>属性を使用します。</p>
 <div class="example">
   <p>この例で、サイトのホームページを指すリンクは、家のアイコン画像とテキスト"自宅"を含みます。画像は、空の<code>alt</code>テキストを持ちます。画像がこの方法で使用される場合、CSSを使用して画像を追加することが適切でもあります。</p>
-  <p><img width="100" height="38" alt="単語'ホーム'の隣にある家のアイコン。" src="images/home.png"></p>
+  <p><img width="100" height="38" alt="単語'ホーム'の隣にある家のアイコン。" src="http://www.w3.org/TR/html-alt-techniques/images/home.png"></p>
   <pre><code class="block">&lt;a href="home.html"&gt;&lt;img src="home.gif" width="15" height="15" <mark>alt=""</mark>&gt;Home&lt;/a&gt;
 
 #home:before { content: url(home.png);}
@@ -824,14 +824,14 @@ for Kingston upon Thames.&lt;/p&gt;    </code></pre>
 </div>
 <div tabindex="-1" class="example" id="hba">
   <p>この例で、警告アイコンを伴う警告メッセージがあります。単語"警告！"はアイコンの次の強調テキストです。アイコンによって伝えられる情報が冗長であるため、img要素は空のalt属性が与えられます。</p>
-  <p><img width="38" height="34" alt="警告！" src="images/warning.png"><strong>Warning!</strong> Your session is about to expire.</p>
+  <p><img width="38" height="34" alt="警告！" src="http://www.w3.org/TR/html-alt-techniques/images/warning.png"><strong>Warning!</strong> Your session is about to expire.</p>
   <pre><code class="block">&lt;p&gt;&lt;img src="warning.png" width="15" height="15" <mark>alt=""</mark>&gt;
 &lt;strong&gt;Warning!&lt;/strong&gt; Your session is about to expire&lt;/p&gt;</code></pre>
 </div>
 <p>When an icon conveys additional information not available in text, provide a text alternative.</p>
 <div class="example">
   <p>この例で、警告アイコンを伴う警告メッセージがあります。アイコンは、メッセージの重要性を強調し、特定の内容型として識別します。</p>
-  <p><img width="38" height="34" alt="警告！" src="images/warning.png"><strong>Your session is about to expire.</strong></p>
+  <p><img width="38" height="34" alt="警告！" src="http://www.w3.org/TR/html-alt-techniques/images/warning.png"><strong>Your session is about to expire.</strong></p>
   <pre><code class="block">&lt;p&gt;&lt;img src="warning.png" width="15" height="15" <mark>alt="Warning!"</mark>&gt;
   Your session is about to expire&lt;/p&gt;</code></pre>
 </div>
@@ -847,14 +847,14 @@ for Kingston upon Thames.&lt;/p&gt;    </code></pre>
 <p>たとえばページの見出しのように、ロゴが団体を表すために使用されている場合、代替テキストとしてはロゴによって表されるその団体の名前を提供します。</p>
 <div class="example">
   <p>この例は、自身を表現するために使用されているWebPlatform.orgロゴの使用を示します。</p>
-  <p><img width="110" height="100" alt="WebPlatform.org" src="images/logo-with-text.png">  and other developer resources</p>
+  <p><img width="110" height="100" alt="WebPlatform.org" src="http://www.w3.org/TR/html-alt-techniques/images/logo-with-text.png">  and other developer resources</p>
   <pre><code class="block">&lt;h2&gt;&lt;img src="images/webplatform.png" <mark>alt="WebPlatform.org"</mark>&gt; and other developer resources&lt;h2&gt;</code></pre>
   <p>上記の例における代替テキストはまた、画像コンテンツのタイプを説明するために単語"logo"を含むかもしれません。そのような場合、この情報を表現するために角括弧を用いることが提案されます：<code>alt="[logo] WebPlatform.org"</code>。</p>
 </div>
 <p>ロゴが表すエンティティの名前の横にロゴが使用される場合、そのロゴは補足である。代替テキストがすでに提供されているように空の<code>alt</code>属性を含みます。</p>
 <div class="example">
   <p>この例は、ロゴが表す組織名の横にロゴマークの使用を示します。</p>
-  <p><img width="72" height="68" alt="" src="images/webplatform.png">  WebPlatform.org</p>
+  <p><img width="72" height="68" alt="" src="http://www.w3.org/TR/html-alt-techniques/images/webplatform.png">  WebPlatform.org</p>
   <pre><code class="block">&lt;img src="images/webplatform1.png" <mark>alt=""</mark>&gt; WebPlatform.org</code></pre>
 </div>
 <p>ロゴが表す主題または団体を説明するテキストと同時にロゴが使用される場合、ロゴを説明する代替テキストを提供します。</p>
@@ -875,7 +875,7 @@ prominent on the face of the shield."</mark>&gt;&lt;/p&gt;
 <p class="warning">CAPTCHAのすべての形態は、障害をもつユーザーに対する入力への容認できない障壁を導入するため、CAPTCHAの代替品を使用することを強く推奨します。更なる情報は、W3Cの<a href="http://www.w3.org/TR/turingtest/">Inaccessibility of CAPTCHA</a>で利用可能です。</p>
 <div class="example">
   <p>この例では、文字の歪んだ画像を使用するCAPTCHAのテストを示します。<code>alt</code>属性における代替テキストは、画像コンテンツにアクセスできない場合にユーザーに対する手順を説明します。 </p>
-  <p><img width="270" height="60" alt="captcha containing the words 'aides' and 'sprucest'. The letters are distorted and the color of the letters and background is partially inverted," src="images/captcha.png"></p>
+  <p><img width="270" height="60" alt="captcha containing the words 'aides' and 'sprucest'. The letters are distorted and the color of the letters and background is partially inverted," src="http://www.w3.org/TR/html-alt-techniques/images/captcha.png"></p>
   <pre><code class="block">&lt;img src="captcha.png" <mark>alt="If you cannot view this image an audio challenge is provided."</mark>&gt;
  &lt;!-- audio CAPTCHA option that allows the user to listen and type the word --&gt;
  &lt;!-- form that asks a question --&gt; </code>   </pre>


### PR DESCRIPTION
Some images references `images/*`, but these files are not found. Referencing
`http://www.w3.org/TR/html-alt-techniques/images/*` could fix this issue.
