### PR TITLE
[wai-aria-1.1] Fix typo

### DIFF
--- a/wai-aria-1.1/index.html
+++ b/wai-aria-1.1/index.html
@@ -9219,7 +9219,7 @@ table.simple {
 		</div>
 		<hr>
 		<div class="state" id="aria-expanded">
-			<h3 id="aria-expanded-state"><span aria-describedby="desc-aria-expanded" title="aria-expanded" class="state-name"><code>aria-disabled</code> <span class="type-indicator">（ステート）</span></span><span typeof="bookmark" class="permalink"><a property="url" title="Permalink for aria-expanded (state)" aria-label="Permalink for aria-expanded (state)" href="#aria-expanded"><span content="aria-expanded (state)" property="title">§</span></a></span></h3>
+			<h3 id="aria-expanded-state"><span aria-describedby="desc-aria-expanded" title="aria-expanded" class="state-name"><code>aria-expanded</code> <span class="type-indicator">（ステート）</span></span><span typeof="bookmark" class="permalink"><a property="url" title="Permalink for aria-expanded (state)" aria-label="Permalink for aria-expanded (state)" href="#aria-expanded"><span content="aria-expanded (state)" property="title">§</span></a></span></h3>
 			<div role="definition" id="desc-aria-expanded" class="state-description">
 				<p>要素、または要素が制御する別のグループ化要素が、現在展開されるまたは折りたたまれるかどうかを示す。</p>
 				<p>これは、たとえば、ツリーの一部を展開または折りたたみされるかどうかを示す。他の例において、これは、コンテンツ密度を管理するための柔軟な展開可能かつ折り畳み可能な領域をマークするためにページのセクションに適用することができる。折りたたみセクションによってユーザーインターフェースを簡素化することは、認知や発達障害をもつ人も含め、すべての人に対するユーザービリティを向上させることができる。</p>


### PR DESCRIPTION
```aria-expanded``` の見出しが ```aria-disabled``` になっていました。