### PR TITLE
[css-2015] Fix section 4.2.

### DIFF
--- a/css-2015/index.html
+++ b/css-2015/index.html
@@ -377,70 +377,70 @@
      </td></th></tr><tr>
       <th scope="row">  E:nth-child(n) 
        
-      <td>n番目の子であるE要素 
+      <td>E要素の親に属するn番目の子となる、E要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:nth-last-child(n) 
        
-      <td>最後から数えてn番目の子であるE要素 
+      <td>E要素の親に属する最後から数えてn番目の子となる、E要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:nth-of-type(n) 
        
-      <td>n番目の兄弟であるE要素 
+      <td>E要素型のn番目の兄弟となる、E要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:nth-last-of-type(n) 
        
-      <td>最後から数えてn番目の兄弟であるE要素 
+      <td>E要素型の最後から数えてn番目の兄弟となる、E要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:first-child 
        
-      <td>最初の子であるE要素 
+      <td>E要素の親に属する最初の子となる、E要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>2 
       
      </td></th></tr><tr>
       <th scope="row">  E:last-child 
        
-      <td>最後の子であるE要素 
+      <td>E要素の親に属する最後の子となる、E要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:first-of-type 
        
-      <td>最初の兄弟であるE要素 
+      <td>E要素型の最初の兄弟となる、E要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:last-of-type 
        
-      <td>最後の兄弟であるE要素 
+      <td>E要素型の最後の兄弟となる、E要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:only-child 
        
-      <td>唯一の子であるE要素 
+      <td>E要素の親に属する唯一の子となる、E要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:only-of-type 
        
-      <td>唯一の兄弟であるE要素 
+      <td>E要素型の唯一の兄弟となる、E要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       

--- a/css-2015/index.html
+++ b/css-2015/index.html
@@ -377,70 +377,70 @@
      </td></th></tr><tr>
       <th scope="row">  E:nth-child(n) 
        
-      <td>親がE要素で、その要素のn番目の子 
+      <td>n番目の子であるE要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:nth-last-child(n) 
        
-      <td>親がE要素で、その要素の最後から数えてn番目の子 
+      <td>最後から数えてn番目の子であるE要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:nth-of-type(n) 
        
-      <td>親がE要素で、その要素型のn番目の子 
+      <td>n番目の兄弟であるE要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:nth-last-of-type(n) 
        
-      <td>親がE要素で、その要素型の最後から数えてn番目の子 
+      <td>最後から数えてn番目の兄弟であるE要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:first-child 
        
-      <td>親がE要素で、その要素の最初の子 
+      <td>最初の子であるE要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>2 
       
      </td></th></tr><tr>
       <th scope="row">  E:last-child 
        
-      <td>親がE要素で、その要素の最後の子 
+      <td>最後の子であるE要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:first-of-type 
        
-      <td>E要素型で、その要素型の最初の兄弟 
+      <td>最初の兄弟であるE要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:last-of-type 
        
-      <td>E要素型で、その要素型の最後の兄弟 
+      <td>最後の兄弟であるE要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:only-child 
        
-      <td>親がE要素で、その要素の唯一の子 
+      <td>唯一の子であるE要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       
      </td></th></tr><tr>
       <th scope="row">  E:only-of-type 
        
-      <td>E要素型で、その要素型の唯一の兄弟 
+      <td>唯一の兄弟であるE要素 
       </td><td><a href="http://standards.mitsue.co.jp/resources/w3c/TR/css3-selectors/#structural-pseudos">構造擬似クラス</a> 
       </td><td>3 
       


### PR DESCRIPTION
### 概要

構造擬似クラス `E:*-child` および、`E:*-of-type`の意味が異なるようなのでプルリクエストを送ります。

### 詳細

> E:first-child	親がE要素で、その要素の最初の子

とあります。
これは一見、`h2:first-child` とすると `親がh2要素の、最初の子要素`を示しそうだと読みとれます。

しかし、http://momdo.github.io/css-2015/index.html にてChromeの開発者ツール > Elements (Firefoxは Inspector) > Ctrl + F の要素検索にて、`h2:first-child` を検索すると、h2要素の、最初の子要素であるspanでなく、

`<h2 class="heading settled" data-level="1" id="intro">`

がマッチします。
実際には`最初の子である、h2要素`を示しているようです。

他の構造擬似クラスにも同様のことが言えましたので、`E`要素は親要素を示すのではなく、あくまでもマッチする対象の子要素または兄弟要素であることを明示する文言に変更しました。