### PR TITLE
[html-aria] 「HTML要素ごとのARIA属性利用の規則」表の `<li>` 要素の誤訳修正

### DIFF
--- a/html-aria/index.html
+++ b/html-aria/index.html
@@ -976,7 +976,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <p>そうでなければ、<code>li</code>がリスト要素の子でない場合、<code>role=<a href="#index-aria-generic">generic</a></code>として公開される。</p>
             </td>
             <td><div class="proposed correction"><p><strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-34"><code>listitem</a></code>以外の<code>role</code></a>なし</strong>。これは、親のリスト要素が暗黙的または明示的な<code>list</code>ロールを持つ場合、<em class="rfc2119">推奨されない</em>。</p>
-                <p>そうでなければ、親のリスト項目が暗黙的または明示的な<code>list</code>ロールを公開する場合、<a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-22"><strong>すべての<code>role</code></strong></a>。</p>
+                <p>そうでなければ、親のリスト項目が暗黙的または明示的な<code>list</code>ロールを公開しない場合、<a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-22"><strong>すべての<code>role</code></strong></a>。</p>
                 <div class="note" role="note" id="issue-container-generatedID-3"><div role="heading" class="note-title marker" id="h-note-5" aria-level="3"><span>注</span></div><p class="">リスト要素に許可されているロールについては、<a href="#el-ul"><code>ul</code></a>、<a href="#el-ol"><code>ol</code></a>、または<a href="#el-menu"><code>menu</code></a>を参照。</p></div>
               </div>
               <p><a href="https://momdo.github.io/wai-aria-1.2/#global_states">グローバル<code>aria-*</code>属性</a>および許可されるロールに受け入れ可能なすべての<code>aria-*</code>属性</p>


### PR DESCRIPTION
https://momdo.github.io/html-aria/#el-li

公開する→公開しない
※原文は「does nto expose」